### PR TITLE
Ensure users receive `delete_response` event

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,6 +135,7 @@ def on_delete(data):
             )
         else:
             room = room_info["room_name"]
+            join_room(room)
             delete_room(room_id)
             socketio.emit(
                 "delete_response",


### PR DESCRIPTION
### Description
**Server-Side Update:** Modify the `on_delete` function to make users join the room on the server side before emitting the `delete_response` event. This ensures the owner of the room immediately receives the `delete_response` event.
#8 